### PR TITLE
Define warning() when in debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-	set(CMAKE_C_FLAGS_DEBUG "-std=c11 -Wall -Wextra -Werror -Wpedantic -g -O0")
+	set(CMAKE_C_FLAGS_DEBUG "-std=c11 -Wall -Wextra -Werror -Wpedantic -g -O0 -DDEBUG=1")
 	set(CMAKE_C_FLAGS_RELEASE "-std=c11 -O1")
 endif()
 
@@ -29,4 +29,3 @@ target_include_directories(${LIB} PRIVATE "${CMAKE_SOURCE_DIR}/include/")
 
 install(TARGETS ${LIB} DESTINATION lib)
 install(FILES ${HEADER} DESTINATION include)
-

--- a/include/libconf.h
+++ b/include/libconf.h
@@ -1,6 +1,8 @@
 #ifndef LIBCONF_H
 #define LIBCONF_H
 
+#include <stddef.h>
+
 typedef struct lc_token {
 	char* string;
 	size_t len;


### PR DESCRIPTION
I noticed that multiple places in the code did had the warning function
commented out, so instead of just removing them the better solution
was to use the already existing release/debug system. When compiling
under debug mode, CMake defines DEBUG=1 which in turn enables the
warning() function. Otherwise it's an empty macro.